### PR TITLE
chore: terraform reads humctl now

### DIFF
--- a/0_install.sh
+++ b/0_install.sh
@@ -17,9 +17,6 @@ fi
 kubeconfig_docker=/state/kube/config-internal.yaml
 kind export kubeconfig --internal  -n 5min-idp --kubeconfig "$kubeconfig_docker"
 
-humctl_token=$(yq .token /root/.humctl)
-
-export HUMANITEC_TOKEN=$humctl_token
 export TF_VAR_humanitec_org=$HUMANITEC_ORG
 export TF_VAR_kubeconfig=$kubeconfig_docker
 

--- a/2_cleanup.sh
+++ b/2_cleanup.sh
@@ -7,10 +7,8 @@ if [ "$(docker inspect -f='{{json .NetworkSettings.Networks.kind}}' "${container
   docker network connect "kind" "${container_name}"
 fi
 
-humctl_token=$(yq .token /root/.humctl)
 kubeconfig_docker=/state/kube/config-internal.yaml
 
-export HUMANITEC_TOKEN=$humctl_token
 export TF_VAR_humanitec_org=$HUMANITEC_ORG
 export TF_VAR_kubeconfig=$kubeconfig_docker
 

--- a/setup/terraform/providers.tf
+++ b/setup/terraform/providers.tf
@@ -10,7 +10,7 @@ terraform {
     }
     humanitec = {
       source  = "humanitec/humanitec"
-      version = "~> 1.3"
+      version = "~> 1.6"
     }
     random = {
       source  = "hashicorp/random"


### PR DESCRIPTION
The humanitec terraform provider now supports fetching the token from `~/.humctl` automatically, so we can remove the manual forwarding.