### PR TITLE
Use current postgres-basic module

### DIFF
--- a/setup/terraform/idp-base.tf
+++ b/setup/terraform/idp-base.tf
@@ -72,7 +72,7 @@ resource "humanitec_resource_definition_criteria" "dns_localhost" {
 # Provide postgres resource
 
 module "postgres_basic" {
-  source = "github.com/humanitec-architecture/resource-packs-in-cluster//humanitec-resource-defs/postgres/basic?ref=v2024-06-05"
+  source = "github.com/humanitec-architecture/resource-packs-in-cluster//humanitec-resource-defs/postgres/basic?ref=v2024-06-07"
   prefix = local.prefix
 }
 


### PR DESCRIPTION
The `postgres_basic` Terraform module used to create the Resource Definition for the in-cluster postgres from the Resource Pack uses an outdated version [v2024-06-05](https://github.com/humanitec-architecture/resource-packs-in-cluster/releases/tag/v2024-06-05). The current version is [v2024-06-07](https://github.com/humanitec-architecture/resource-packs-in-cluster/releases/tag/v2024-06-07).

To see the changes in the versions between the two In-cluster Resource Pack releases, go [here](https://github.com/humanitec-architecture/resource-packs-in-cluster/compare/v2024-06-05...v2024-06-07).

Let's update the reference so that the Resource Definition is using the now [recommended way](https://developer.humanitec.com/integration-and-extensions/drivers/generic-drivers/template/#working-with-secrets) of creating secret outputs in the Template Driver.

~~When executing the 5-min-IDP setup, `terraform apply` fails with an error 500 when trying to create than Resource Definition.~~
~~Changing the source to the current version fixes it.~~
-> Working again, this seems to have been a temporary glitch in the Orchestrator.
