### PR TITLE
fix: update demo to use newapp-io drivers

### DIFF
--- a/1_demo.sh
+++ b/1_demo.sh
@@ -13,9 +13,9 @@ echo "Waiting for workload to be available"
 
 # manually change the host here as the workload host resolves to localhost, which is not reachable from the container
 if curl -I --retry 30 --retry-delay 3 --retry-all-errors --fail \
-  --connect-to "$workload_host:30080:5min-idp-control-plane:30080" \
-  "http://$workload_host:30080"; then
-  echo "Workload available at: http://$workload_host:30080"
+  --connect-to "$workload_host:30443:5min-idp-control-plane:30443" \
+  "https://$workload_host:30443"; then
+  echo "Workload available at: https://$workload_host:30443"
 else
   echo "Workload not available"
   kubectl get pods --all-namespaces

--- a/setup/kind/cluster.yaml
+++ b/setup/kind/cluster.yaml
@@ -6,5 +6,7 @@ nodes:
   extraPortMappings:
   - containerPort: 30080
     hostPort: 30080
-    listenAddress: "0.0.0.0"
     protocol: TCP
+  - containerPort: 30443
+    hostPort: 30443
+    protocol: TCP    

--- a/setup/terraform/idp-base.tf
+++ b/setup/terraform/idp-base.tf
@@ -45,11 +45,10 @@ resource "humanitec_resource_definition" "dns_localhost" {
   id          = "${local.prefix}dns-localhost"
   name        = "${local.prefix}dns-localhost"
   type        = "dns"
-  driver_type = "humanitec/dns-wildcard"
+  driver_type = "humanitec/newapp-io-dns"
 
   driver_inputs = {
     values_string = jsonencode({
-      "domain"   = "localhost"
       "template" = "$${context.app.id}-{{ randAlphaNum 4 | lower}}"
     })
   }

--- a/setup/terraform/idp-cluster.tf
+++ b/setup/terraform/idp-cluster.tf
@@ -78,7 +78,7 @@ resource "humanitec_resource_definition" "cluster_local" {
 
   driver_inputs = {
     values_string = jsonencode({
-      loadbalancer = "0.0.0.0" # ensure dns records are created pointing to localhost
+      loadbalancer = "127.0.0.1" # ensure dns records are created pointing to localhost
       cluster_data = local.parsed_kubeconfig["clusters"][0]["cluster"]
     })
     secrets_string = jsonencode({

--- a/setup/terraform/idp-ingress.tf
+++ b/setup/terraform/idp-ingress.tf
@@ -25,4 +25,9 @@ resource "helm_release" "ingress_nginx" {
     name  = "controller.service.nodePorts.http"
     value = "30080"
   }
+
+  set {
+    name  = "controller.service.nodePorts.https"
+    value = "30443"
+  }
 }


### PR DESCRIPTION
This updates the idp image to use the [newapp-io drivers](https://developer.humanitec.com/integration-and-extensions/drivers/dns-drivers/newapp.io/). Particularly:

- dns definition is updated to use the new driver (as tls-cert default definition validates .newapp.io subdomain now)
- cluster definition is updated to set localhost as loadbalancer
- 30443 is exposed to handle https cluster

Tested on Mac Os.

<img width="1696" alt="Screenshot 2024-10-11 at 14 39 59" src="https://github.com/user-attachments/assets/0b9807b1-0868-4152-a1aa-2505ee7ff3d6">

