### PR TITLE
Make sure that humanitec environment is created

### DIFF
--- a/1_demo.sh
+++ b/1_demo.sh
@@ -4,10 +4,11 @@ set -eo pipefail
 echo "Deploying workload"
 
 humanitec_app=$(terraform -chdir=setup/terraform output -raw humanitec_app)
+humanitec_environment=$(terraform -chdir=setup/terraform output -raw humanitec_environment)
 
-humctl score deploy --app "$humanitec_app" --env development -f ./score.yaml --wait
+humctl score deploy --app "$humanitec_app" --env "$humanitec_environment" -f ./score.yaml --wait
 
-workload_host=$(humctl get active-resources --app "$humanitec_app" --env development -o yaml | yq '.[] | select(.metadata.type == "route") | .status.resource.host')
+workload_host=$(humctl get active-resources --app "$humanitec_app" --env "$humanitec_environment" -o yaml | yq '.[] | select(.metadata.type == "route") | .status.resource.host')
 
 echo "Waiting for workload to be available"
 
@@ -19,6 +20,6 @@ if curl -I --retry 30 --retry-delay 3 --retry-all-errors --fail \
 else
   echo "Workload not available"
   kubectl get pods --all-namespaces
-  kubectl -n "$humanitec_app-development" logs deployment/hello-world
+  kubectl -n "$humanitec_app-$humanitec_environment" logs deployment/hello-world
   exit 1
 fi

--- a/setup/terraform/idp-base.tf
+++ b/setup/terraform/idp-base.tf
@@ -10,7 +10,7 @@ resource "random_string" "install_id" {
 locals {
   app         = "5min-idp-${random_string.install_id.result}"
   prefix      = "${local.app}-"
-  enviornment = "development-${random_string.install_id.result}"
+  environment = "development-${random_string.install_id.result}"
 }
 
 resource "humanitec_application" "demo" {
@@ -20,7 +20,7 @@ resource "humanitec_application" "demo" {
 
 resource "humanitec_environment" "demo" {
   app_id = humanitec_application.demo.id
-  id     = local.enviornment
+  id     = local.environment
   name   = "A demo environment for 5min-idp"
   type   = "development"
 }

--- a/setup/terraform/idp-base.tf
+++ b/setup/terraform/idp-base.tf
@@ -8,13 +8,21 @@ resource "random_string" "install_id" {
 }
 
 locals {
-  app    = "5min-idp-${random_string.install_id.result}"
-  prefix = "${local.app}-"
+  app         = "5min-idp-${random_string.install_id.result}"
+  prefix      = "${local.app}-"
+  enviornment = "development-${random_string.install_id.result}"
 }
 
 resource "humanitec_application" "demo" {
   id   = local.app
   name = local.app
+}
+
+resource "humanitec_environment" "demo" {
+  app_id = humanitec_application.demo.id
+  id     = local.enviornment
+  name   = "A demo environment for 5min-idp"
+  type   = "development"
 }
 
 # Configure k8s namespace naming

--- a/setup/terraform/outputs.tf
+++ b/setup/terraform/outputs.tf
@@ -2,3 +2,8 @@ output "humanitec_app" {
   description = "The ID of the Humanitec application"
   value       = humanitec_application.demo.id
 }
+
+output "humanitec_environment" {
+  description = "The ID of the Humanitec environment"
+  value       = humanitec_environment.demo.id
+}


### PR DESCRIPTION
When running the 5min-idp tutorial, the script `1_demo.sh` fails with this error message:

```
5min-idp:/app# ./1_demo.sh 
Deploying workload
Unexpected error occurred.
unexpected api response when creating deployment: 400, {"error":"API-400","message":"environment 'development' not found"}

```

when the environment `development` does not exist in the organization. This PR creates a new environment for the IDP and uses it to deploy the app to it, thus eliminating the assumption that the environment already exists, which is not true for all organizations by default.