### PR TITLE
fix: fake vault url

### DIFF
--- a/setup/terraform/idp-cluster.tf
+++ b/setup/terraform/idp-cluster.tf
@@ -153,6 +153,6 @@ resource "humanitec_secretstore" "kubernetes_secret_store" {
   id      = "5min-idp-secrets"
   primary = true
   vault = {
-    url = "https://example.com"
+    url = "http://fake-vault"
   }
 }


### PR DESCRIPTION
As this URL may be requested if a user will try to write secrets via the Orchestrator, it's better to use some internal fake URL here.